### PR TITLE
Added processing to prevent to restoring specific Entry

### DIFF
--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -5022,3 +5022,17 @@ class ModelTest(AironeTestCase):
             ),
             (True, None),
         )
+
+    def test_check_duplication_entry_at_restoring1(self):
+        """
+        Test case confirms to fail to restore EntryA at following case
+        * EntryA -> EntryB (there is another active Entry which is same name)
+        """
+        pass
+
+    def test_check_duplication_entry_at_restoring2(self):
+        """
+        Test case confirms to fail to restore EntryA at following case
+        * EntryA -> EntryB -> EntryC(there is another active Entry which is same name)
+        """
+        pass

--- a/entry/views.py
+++ b/entry/views.py
@@ -721,6 +721,18 @@ def do_restore(request, entry_id, recv_data):
             status=400,
         )
 
+    ###
+    ## entryA[EntityA] -> entryB[EntityA] -> entryC[EntityA] (duplicated)
+
+    ## valiadstion processing for checking duplication of entry that "is_delete_in_chain" paramtere is seetting
+    if entry.check_duplication_entry_at_restoring():
+        return JsonResponse(
+            data={
+                "msg": "Failed %s has referral that will be duplicate with other Entry" % entry.name
+            },
+            status=400,
+        )
+
     entry.set_status(Entry.STATUS_CREATING)
 
     # Create a new job to restore deleted entry and run it


### PR DESCRIPTION
This commit has implementation to prevent to restoring Entry that has referral to other deleted Entry, which there is another same name active Entry in the same Entity.

NOTE:
This commit doesn't have test of adding code. Please add it.